### PR TITLE
Bugfix/wrap around

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 devel
 
 profile.tmp
+
+*.bag

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ devel
 profile.tmp
 
 *.bag
+./bagfiles

--- a/ros/src/waypoint_loader/waypoint_loader.py
+++ b/ros/src/waypoint_loader/waypoint_loader.py
@@ -54,7 +54,11 @@ class WaypointLoader(object):
                 p.twist.twist.linear.x = float(self.velocity)
 
                 waypoints.append(p)
-        return self.decelerate(waypoints)
+        # In starter code, decelaration was issued for last points to make car stop.
+        #return self.decelerate(waypoints)
+        
+        # For wrap-around / endless driving mode, this step is not used anymore.
+        return waypoints
 
     def distance(self, p1, p2):
         x, y, z = p1.x - p2.x, p1.y - p2.y, p1.z - p2.z

--- a/ros/src/waypoint_loader/waypoint_loader.py
+++ b/ros/src/waypoint_loader/waypoint_loader.py
@@ -13,6 +13,7 @@ import rospy
 
 CSV_HEADER = ['x', 'y', 'z', 'yaw']
 MAX_DECEL = 1.0
+WRAP_AROUND = True      # Wrap-around: False=drive one lap, True=drive endlessly
 
 
 class WaypointLoader(object):
@@ -54,11 +55,12 @@ class WaypointLoader(object):
                 p.twist.twist.linear.x = float(self.velocity)
 
                 waypoints.append(p)
-        # In starter code, decelaration was issued for last points to make car stop.
-        #return self.decelerate(waypoints)
-        
-        # For wrap-around / endless driving mode, this step is not used anymore.
-        return waypoints
+        # In starter code, decelaration was issued for last points to make car stop gently.
+        # For wrap-around / endless driving mode, this step is not helpful and therefore unused.
+        if WRAP_AROUND:
+            return waypoints
+        else:
+            return self.decelerate(waypoints)
 
     def distance(self, p1, p2):
         x, y, z = p1.x - p2.x, p1.y - p2.y, p1.z - p2.z

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -62,8 +62,8 @@ class WaypointUpdater(object):
                 closest_waypoint_idx = self.get_closest_waypoint_idx()
 
                 # Set farthest waypoiny
-                farthest_waypoint_idx = closest_waypoint_idx + LOOKAHEAD_WPS
-
+                farthest_waypoint_idx = \
+                    (closest_waypoint_idx + LOOKAHEAD_WPS) %len(self.waypoints_2d)
                 # Publish waypoint
                 self.publish_waypoints(closest_waypoint_idx, farthest_waypoint_idx)
             rate.sleep()
@@ -81,7 +81,16 @@ class WaypointUpdater(object):
 
         # Check if closest is ahead or behind vehicle
         closest_coord = self.waypoints_2d[closest_idx]
-        prev_coord = self.waypoints_2d[closest_idx - 1]
+        if (closest_idx > 0):
+            prev_coord = self.waypoints_2d[closest_idx - 1]
+        elif (closest_idx == 0):
+            prev_coord = self.waypoints_2d[len(self.waypoints_2d)]
+            str_a = 'waypoint_updater.py: lower-bound wrap around occured. '
+            str_b = 'prev_wp=' + str(len(self.waypoints_2d)) + ', '
+            str_c = 'curr_wp=' + str(closest_idx)
+            rospy.loginfo(str_a + str_b + str_c)
+        else:
+            rospy.logerr('waypoint_updater.py: closest_idx < 0, not plausible!')
 
         # Equation for hyperplane through closest_coords
         cl_vect = np.array(closest_coord)

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -80,24 +80,25 @@ class WaypointUpdater(object):
 
         # Check if closest is ahead or behind vehicle
         closest_coord = self.waypoints_2d[closest_idx]
+        # Regular case: somewhere in between the waypoints
         if (closest_idx > 0):
-            # Regular case: somewhere in between the waypoints
             prev_idx = closest_idx - 1
             prev_coord = self.waypoints_2d[prev_idx]
             log_str = 'waypoint_updater.py: regular case, no wrap-around. '
             log_str += 'prev_wp=' + str(prev_idx) + ', '
             log_str += 'curr_wp=' + str(closest_idx)
-            rospy.loginfo_throttle(1,log_str) # Print log only per second for a smaller log file
+            rospy.loginfo(log_str)
+            #rospy.loginfo_throttle(1,log_str) # Print log only each second for a smaller log file
+        # Wrap-around case: closest waypoint equals zero (begin of list) --> wrap-around
         elif (closest_idx == 0):
-            # Wrap-around case: closest waypoint equals zero (begin of list) --> wrap-around
-            prev_idx = len(self.waypoints_2d)-1
+            prev_idx = len(self.waypoints_2d)-1                # choose last index of list
             prev_coord = self.waypoints_2d[prev_idx]
             log_str = 'waypoint_updater.py: lower-bound wrap around occured. '
             log_str += 'prev_wp=' + str(prev_idx) + ', '
             log_str += 'curr_wp=' + str(closest_idx)
             rospy.loginfo(log_str)
+        # Warning case: negative number found
         else:
-            # Warning case: negative number found
             prev_idx = closest_idx - 1
             prev_coord = self.waypoints_2d[prev_idx]
             log_str = 'waypoint_updater.py: WARNING! closest_idx < 0, not plausible! '

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -80,23 +80,23 @@ class WaypointUpdater(object):
 
         # Check if closest is ahead or behind vehicle
         closest_coord = self.waypoints_2d[closest_idx]
-        # Regular case: somewhere in between the waypoints
+        # Regular case: somewhere in between the waypoint list
         if (closest_idx > 0):
             prev_idx = closest_idx - 1
             prev_coord = self.waypoints_2d[prev_idx]
-            log_str = 'waypoint_updater.py: regular case, no wrap-around. '
-            log_str += 'prev_wp=' + str(prev_idx) + ', '
-            log_str += 'curr_wp=' + str(closest_idx)
-            rospy.loginfo(log_str)
+            #log_str = 'waypoint_updater.py: regular case, no wrap-around. '
+            #log_str += 'prev_wp=' + str(prev_idx) + ', '
+            #log_str += 'curr_wp=' + str(closest_idx)
+            #rospy.loginfo(log_str)
             #rospy.loginfo_throttle(1,log_str) # Print log only each second for a smaller log file
         # Wrap-around case: closest waypoint equals zero (begin of list) --> wrap-around
         elif (closest_idx == 0):
             prev_idx = len(self.waypoints_2d)-1                # choose last index of list
             prev_coord = self.waypoints_2d[prev_idx]
-            log_str = 'waypoint_updater.py: lower-bound wrap around occured. '
-            log_str += 'prev_wp=' + str(prev_idx) + ', '
-            log_str += 'curr_wp=' + str(closest_idx)
-            rospy.loginfo(log_str)
+            #log_str = 'waypoint_updater.py: lower-bound wrap around occured. '
+            #log_str += 'prev_wp=' + str(prev_idx) + ', '
+            #log_str += 'curr_wp=' + str(closest_idx)
+            #rospy.loginfo(log_str)
         # Warning case: negative number found
         else:
             prev_idx = closest_idx - 1
@@ -104,8 +104,7 @@ class WaypointUpdater(object):
             log_str = 'waypoint_updater.py: WARNING! closest_idx < 0, not plausible! '
             log_str += 'prev_wp=' + str(prev_idx) + ', '
             log_str += 'curr_wp=' + str(closest_idx)
-            rospy.loginfo(log_str)
-            #rospy.logwarn(log_str)
+            rospy.logwarn(log_str)
 
         # Equation for hyperplane through closest_coords
         cl_vect = np.array(closest_coord)
@@ -125,9 +124,12 @@ class WaypointUpdater(object):
         """
         lane = Lane()
         lane.header = self.base_waypoints.header
-        # Wrap around with numpy take
-        indices = range(closest_idx,farthest_idx)
-        lane.waypoints = np.take(self.base_waypoints.waypoints,indices,mode='wrap')
+        # Wrap around with numpy take. But only where necessary to be more CPU efficient
+        if (farthest_idx > closest_idx):
+            lane.waypoints = self.base_waypoints.waypoints[closest_idx:farthest_idx]
+        else:
+            indices = range(closest_idx,farthest_idx)
+            lane.waypoints = np.take(self.base_waypoints.waypoints,indices,mode='wrap')
 
         self.final_waypoints_pub.publish(lane)
 


### PR DESCRIPTION
Created a wrap-around. Seems like speed was decreased in `waypoint_loader.py` at the end of one loop. This was the first necessary fix.

Second fix was in `waypoint_updater.py`. To realize wrap-around, `np.take` was implemented. However, only where necessary, since `np.take` is quite resource intensive (half a cpu core...). 

A switch was added in `waypoint_loader.py`, so that wrap-around functionality can be deactivated, if desired. 

Both options were tested and are working nicely.  

Fixes #15.